### PR TITLE
メモページの最低限の機能を実装

### DIFF
--- a/apps/web/_test_/memo.page.test.tsx
+++ b/apps/web/_test_/memo.page.test.tsx
@@ -1,0 +1,291 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MockedProvider } from "@apollo/client/testing";
+import type { ComponentType } from "react";
+import { GET_MEMO, SET_HORSE_PROP, SET_FIELD_VALUE } from "@/components/memo/queries";
+
+// useParamsのモック
+const mockParams = { id: "test-memo-id" };
+vi.mock("next/navigation", () => ({
+  useParams: () => mockParams,
+}));
+
+// テストデータ
+const mockMemo = {
+  id: "test-memo-id",
+  name: "テスト競馬メモ",
+  path: "/test-memo",
+  type: "memo",
+  horses: [
+    {
+      name: "テストホース1",
+      predictionMark: "HONMEI",
+      fields: [
+        { label: "オッズ", type: "NUMBER", value: 2.5 },
+        { label: "コメント", type: "COMMENT", value: "期待大" }
+      ]
+    },
+    {
+      name: "テストホース2", 
+      predictionMark: "KESHI",
+      fields: [
+        { label: "オッズ", type: "NUMBER", value: 10.0 },
+        { label: "コメント", type: "COMMENT", value: "微妙" }
+      ]
+    }
+  ]
+};
+
+const successMocks = [
+  {
+    request: {
+      query: GET_MEMO,
+      variables: { id: "test-memo-id" }
+    },
+    result: {
+      data: { item: mockMemo }
+    }
+  },
+  // refetchのためのクエリ（編集後）
+  {
+    request: {
+      query: GET_MEMO,
+      variables: { id: "test-memo-id" }
+    },
+    result: {
+      data: { item: mockMemo }
+    }
+  },
+  {
+    request: {
+      query: SET_HORSE_PROP,
+      variables: { memoId: "test-memo-id", index: 0, predictionMark: "TAIKOU" }
+    },
+    result: {
+      data: { setHorseProp: true }
+    }
+  },
+  {
+    request: {
+      query: SET_HORSE_PROP,
+      variables: { memoId: "test-memo-id", index: 0, name: "新しい馬名" }
+    },
+    result: {
+      data: { setHorseProp: true }
+    }
+  },
+  {
+    request: {
+      query: SET_FIELD_VALUE,
+      variables: { memoId: "test-memo-id", index: 0, label: "オッズ", type: "NUMBER", value: 3.0 }
+    },
+    result: {
+      data: { setFieldValue: true }
+    }
+  }
+];
+
+const loadingMocks = [
+  {
+    request: {
+      query: GET_MEMO,
+      variables: { id: "test-memo-id" }
+    },
+    delay: 1000,
+    result: {
+      data: { item: mockMemo }
+    }
+  }
+];
+
+const errorMocks = [
+  {
+    request: {
+      query: GET_MEMO,
+      variables: { id: "test-memo-id" }
+    },
+    error: new Error("データの取得に失敗しました")
+  }
+];
+
+async function loadMemoPage(): Promise<ComponentType<any>> {
+  const mod = await import("@/components/memo/MemoPage");
+  return mod.MemoPage as ComponentType<any>;
+}
+
+describe("MemoPage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("ローディング状態を表示する", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={loadingMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    expect(screen.getByText("読み込み中…")).toBeInTheDocument();
+  });
+
+  it("エラー状態を表示する", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={errorMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/読み込みエラー/)).toBeInTheDocument();
+    });
+  });
+
+  it("メモデータを正常に表示する", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト競馬メモ")).toBeInTheDocument();
+    });
+
+    // 馬名の表示確認
+    expect(screen.getByDisplayValue("テストホース1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("テストホース2")).toBeInTheDocument();
+
+    // 番号列の表示確認
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    // フィールド値の表示確認
+    expect(screen.getByDisplayValue("2.5")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("期待大")).toBeInTheDocument();
+  });
+
+  it("予想印が消の馬の行が暗くなる", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト競馬メモ")).toBeInTheDocument();
+    });
+
+    // KESHI（消）の馬の行の背景色が設定されていることを確認
+    const keshiHorseInput = screen.getByDisplayValue("テストホース2");
+    const keshiRow = keshiHorseInput.closest('div[style*="rgba(0, 0, 0, 0.4)"]');
+    expect(keshiRow).toBeInTheDocument();
+  });
+
+  it("馬名を編集できる", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("テストホース1")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByDisplayValue("テストホース1");
+    
+    // 値を変更してblurイベントを発火
+    fireEvent.change(nameInput, { target: { value: "新しい馬名" } });
+    fireEvent.blur(nameInput);
+
+    // 保存中の表示確認
+    await waitFor(() => {
+      expect(screen.getByText("保存中…")).toBeInTheDocument();
+    });
+  });
+
+  it("フィールド値を編集できる", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("2.5")).toBeInTheDocument();
+    });
+
+    const oddsInput = screen.getByDisplayValue("2.5");
+    
+    // 値を変更してblurイベントを発火
+    fireEvent.change(oddsInput, { target: { value: "3.0" } });
+    fireEvent.blur(oddsInput);
+
+    // 保存中の表示確認
+    await waitFor(() => {
+      expect(screen.getByText("保存中…")).toBeInTheDocument();
+    });
+  });
+
+  it("存在しないメモIDの場合にエラーメッセージを表示する", async () => {
+    const notFoundMocks = [
+      {
+        request: {
+          query: GET_MEMO,
+          variables: { id: "test-memo-id" }
+        },
+        result: {
+          data: { item: null }
+        }
+      }
+    ];
+
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={notFoundMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("メモが見つかりません")).toBeInTheDocument();
+    });
+  });
+
+  it("Enterキーで次の行にフォーカスが移動する", async () => {
+    const MemoPage = await loadMemoPage();
+    
+    render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <MemoPage />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("テストホース1")).toBeInTheDocument();
+    });
+
+    const firstNameInput = screen.getByDisplayValue("テストホース1");
+    
+    // Enterキーを押下
+    fireEvent.keyDown(firstNameInput, { key: "Enter" });
+
+    // フォーカスが次の行に移動することを確認（実装の詳細によって調整が必要）
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(firstNameInput);
+    }, { timeout: 100 });
+  });
+});

--- a/apps/web/_test_/memo.table-components.test.tsx
+++ b/apps/web/_test_/memo.table-components.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TableRow } from "@/components/memo/table/TableRow";
+import { EditableCell } from "@/components/memo/table/EditableCell";
+import { MarkSwitcher } from "@/components/memo/table/MarkSwitcher";
+import { TableHeader } from "@/components/memo/table/TableHeader";
+import type { Horse, PredictionMark, FieldType } from "@/components/memo/types";
+
+describe("TableRow", () => {
+  const mockHorse: Horse = {
+    name: "テストホース",
+    predictionMark: "HONMEI",
+    fields: [
+      { label: "オッズ", type: "NUMBER", value: 2.5 },
+      { label: "コメント", type: "COMMENT", value: "期待" }
+    ]
+  };
+
+  const mockProps = {
+    horse: mockHorse,
+    rowIndex: 0,
+    gridTemplate: "56px 56px 200px 100px 150px",
+    colLabels: ["オッズ", "コメント"],
+    onChangeMark: vi.fn(),
+    onBlurName: vi.fn(),
+    onBlurField: vi.fn(),
+    onFocusRow: vi.fn(),
+    nameInputRef: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("通常の行を正しく表示する", () => {
+    render(<TableRow {...mockProps} />);
+
+    expect(screen.getByDisplayValue("テストホース")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument(); // rowIndex + 1
+    expect(screen.getByDisplayValue("2.5")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("期待")).toBeInTheDocument();
+    expect(screen.getByText("◎")).toBeInTheDocument(); // HONMEI
+  });
+
+  it("KESHI（消）の馬の行が暗く表示される", () => {
+    const keshiHorse = { ...mockHorse, predictionMark: "KESHI" as PredictionMark };
+    const props = { ...mockProps, horse: keshiHorse };
+
+    render(<TableRow {...props} />);
+
+    // KESHI の場合、背景色が設定されている div を探す
+    const row = screen.getByDisplayValue("テストホース").closest('div[style*="rgba(0, 0, 0, 0.4)"]');
+    expect(row).toBeInTheDocument();
+  });
+
+  it("Enterキーで次の行にフォーカス移動する", async () => {
+    render(<TableRow {...mockProps} />);
+
+    const nameInput = screen.getByDisplayValue("テストホース");
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+
+    expect(mockProps.onBlurName).toHaveBeenCalledWith("テストホース");
+    
+    // setTimeoutを待つ
+    await waitFor(() => {
+      expect(mockProps.onFocusRow).toHaveBeenCalledWith("next");
+    }, { timeout: 100 });
+  });
+
+  it("Shift+Enterキーで前の行にフォーカス移動する", async () => {
+    render(<TableRow {...mockProps} />);
+
+    const nameInput = screen.getByDisplayValue("テストホース");
+    fireEvent.keyDown(nameInput, { key: "Enter", shiftKey: true });
+
+    expect(mockProps.onBlurName).toHaveBeenCalledWith("テストホース");
+    
+    // setTimeoutを待つ
+    await waitFor(() => {
+      expect(mockProps.onFocusRow).toHaveBeenCalledWith("prev");
+    }, { timeout: 100 });
+  });
+
+  it("フィールドがない馬でも正常に表示される", () => {
+    const horseWithoutFields = { ...mockHorse, fields: [] };
+    const props = { ...mockProps, horse: horseWithoutFields, colLabels: [] };
+
+    render(<TableRow {...props} />);
+
+    expect(screen.getByDisplayValue("テストホース")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});
+
+describe("EditableCell", () => {
+  const mockProps = {
+    index: 0,
+    value: "テスト値",
+    type: "COMMENT" as FieldType,
+    onBlur: vi.fn(),
+    onKeyDown: vi.fn(),
+    inputRef: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("値を正しく表示する", () => {
+    render(<EditableCell {...mockProps} />);
+    expect(screen.getByDisplayValue("テスト値")).toBeInTheDocument();
+  });
+
+  it("null値を空文字として表示する", () => {
+    const props = { ...mockProps, value: null };
+    render(<EditableCell {...props} />);
+    
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("");
+  });
+
+  it("数値型の場合にinputModeがdecimalになる", () => {
+    const props = { ...mockProps, type: "NUMBER" as FieldType, value: 123 };
+    render(<EditableCell {...props} />);
+    
+    const input = screen.getByDisplayValue("123");
+    expect(input).toHaveAttribute("inputmode", "decimal");
+  });
+
+  it("プレースホルダーが正しく表示される", () => {
+    const props = { ...mockProps, value: "", placeholder: "入力してください" };
+    render(<EditableCell {...props} />);
+    
+    expect(screen.getByPlaceholderText("入力してください")).toBeInTheDocument();
+  });
+
+  it("値が変更された時のみonBlurが呼ばれる", () => {
+    render(<EditableCell {...mockProps} />);
+    
+    const input = screen.getByDisplayValue("テスト値");
+    
+    // 同じ値でblur - 呼ばれない
+    fireEvent.blur(input);
+    expect(mockProps.onBlur).not.toHaveBeenCalled();
+    
+    // 値を変更してblur - 呼ばれる
+    fireEvent.change(input, { target: { value: "新しい値" } });
+    fireEvent.blur(input);
+    expect(mockProps.onBlur).toHaveBeenCalledWith("新しい値");
+  });
+
+  it("onKeyDownが呼ばれる", () => {
+    render(<EditableCell {...mockProps} />);
+    
+    const input = screen.getByDisplayValue("テスト値");
+    fireEvent.keyDown(input, { key: "Enter" });
+    
+    expect(mockProps.onKeyDown).toHaveBeenCalled();
+  });
+});
+
+describe("MarkSwitcher", () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("現在の予想印を表示する", () => {
+    render(<MarkSwitcher value="HONMEI" onChange={mockOnChange} />);
+    expect(screen.getByText("◎")).toBeInTheDocument();
+  });
+
+  it("クリックで予想印が変更される", () => {
+    render(<MarkSwitcher value="MUZIRUSHI" onChange={mockOnChange} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button);
+    fireEvent.pointerUp(button);
+    
+    // 次の予想印（HONMEI）に変更される
+    expect(mockOnChange).toHaveBeenCalledWith("HONMEI");
+  });
+
+  it("最後の予想印から最初に戻る", () => {
+    render(<MarkSwitcher value="KESHI" onChange={mockOnChange} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button);
+    fireEvent.pointerUp(button);
+    
+    // 最初の予想印（MUZIRUSHI）に戻る
+    expect(mockOnChange).toHaveBeenCalledWith("MUZIRUSHI");
+  });
+});
+
+describe("TableHeader", () => {
+  const mockProps = {
+    gridTemplate: "56px 56px 200px 100px 150px",
+    colLabels: ["オッズ", "コメント"],
+    onStartResize: vi.fn()
+  };
+
+  it("ヘッダーを正しく表示する", () => {
+    render(<TableHeader {...mockProps} />);
+
+    expect(screen.getByText("印")).toBeInTheDocument();
+    expect(screen.getByText("番")).toBeInTheDocument(); // "番号"ではなく"番"
+    expect(screen.getByText("名前")).toBeInTheDocument(); // "馬名"ではなく"名前"
+    expect(screen.getByText("オッズ")).toBeInTheDocument();
+    expect(screen.getByText("コメント")).toBeInTheDocument();
+  });
+
+  it("列ラベルがない場合も正常に表示される", () => {
+    const props = { ...mockProps, colLabels: [], gridTemplate: "56px 56px 200px" };
+    render(<TableHeader {...props} />);
+
+    expect(screen.getByText("印")).toBeInTheDocument();
+    expect(screen.getByText("番")).toBeInTheDocument();
+    expect(screen.getByText("名前")).toBeInTheDocument();
+    expect(screen.queryByText("オッズ")).not.toBeInTheDocument();
+  });
+
+  it("リサイズハンドルが表示される", () => {
+    render(<TableHeader {...mockProps} />);
+
+    // リサイズハンドルの要素をtitleで確認
+    const resizeHandles = screen.getAllByTitle("ドラッグで列の幅を調整");
+    expect(resizeHandles.length).toBe(3); // 名前列 + 2つのフィールド列
+  });
+});

--- a/apps/web/_test_/memo.table.test.tsx
+++ b/apps/web/_test_/memo.table.test.tsx
@@ -1,0 +1,244 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import type { ComponentType } from "react";
+import { MemoTable } from "@/components/memo/table/MemoTable";
+import type { Horse, PredictionMark, FieldType } from "@/components/memo/types";
+
+// テストデータ
+const mockHorses: Horse[] = [
+  {
+    name: "テストホース1",
+    predictionMark: "HONMEI",
+    fields: [
+      { label: "オッズ", type: "NUMBER", value: 2.5 },
+      { label: "コメント", type: "COMMENT", value: "期待大" }
+    ]
+  },
+  {
+    name: "テストホース2",
+    predictionMark: "KESHI", 
+    fields: [
+      { label: "オッズ", type: "NUMBER", value: 10.0 },
+      { label: "コメント", type: "COMMENT", value: "微妙" }
+    ]
+  },
+  {
+    name: "テストホース3",
+    predictionMark: "TAIKOU",
+    fields: [
+      { label: "オッズ", type: "NUMBER", value: 5.0 }
+    ]
+  }
+];
+
+describe("MemoTable", () => {
+  const mockOnChangeMark = vi.fn();
+  const mockOnBlurName = vi.fn();
+  const mockOnBlurField = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ヘッダーとデータ行を正しく表示する", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    // ヘッダーの確認
+    expect(screen.getByText("印")).toBeInTheDocument();
+    expect(screen.getByText("番")).toBeInTheDocument();
+    expect(screen.getByText("名前")).toBeInTheDocument();
+    expect(screen.getByText("オッズ")).toBeInTheDocument();
+    expect(screen.getByText("コメント")).toBeInTheDocument();
+
+    // データ行の確認
+    expect(screen.getByDisplayValue("テストホース1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("テストホース2")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("テストホース3")).toBeInTheDocument();
+
+    // 番号列の確認
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+
+    // フィールド値の確認
+    expect(screen.getByDisplayValue("2.5")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("期待大")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("10")).toBeInTheDocument(); // 10.0 -> 10
+    expect(screen.getByDisplayValue("微妙")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("5")).toBeInTheDocument(); // 5.0 -> 5
+  });
+
+  it("予想印マークを正しく表示する", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    // 予想印の表示確認（MARK_LABELに基づく）
+    expect(screen.getByText("◎")).toBeInTheDocument(); // HONMEI
+    expect(screen.getByText("消")).toBeInTheDocument(); // KESHI
+    expect(screen.getByText("◯")).toBeInTheDocument(); // TAIKOU
+  });
+
+  it("消印の行が暗く表示される", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    // KESHI（消）の馬の行要素を取得
+    const keshiHorseInput = screen.getByDisplayValue("テストホース2");
+    const keshiRow = keshiHorseInput.closest('div[style*="rgba(0, 0, 0, 0.4)"]');
+    
+    // 背景色が設定されていることを確認
+    expect(keshiRow).toBeInTheDocument();
+  });
+
+  it("馬名の編集時にコールバックが呼ばれる", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    const nameInput = screen.getByDisplayValue("テストホース1");
+    
+    fireEvent.change(nameInput, { target: { value: "新しい馬名" } });
+    fireEvent.blur(nameInput);
+
+    expect(mockOnBlurName).toHaveBeenCalledWith(0, "新しい馬名");
+  });
+
+  it("フィールド値の編集時にコールバックが呼ばれる", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    const oddsInput = screen.getByDisplayValue("2.5");
+    
+    fireEvent.change(oddsInput, { target: { value: "3.0" } });
+    fireEvent.blur(oddsInput);
+
+    expect(mockOnBlurField).toHaveBeenCalledWith(0, "オッズ", "NUMBER", "3.0");
+  });
+
+  it("空の馬リストでも正常に表示される", () => {
+    render(
+      <MemoTable
+        horses={[]}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    // ヘッダーは表示される
+    expect(screen.getByText("印")).toBeInTheDocument();
+    expect(screen.getByText("番")).toBeInTheDocument();
+    expect(screen.getByText("名前")).toBeInTheDocument();
+    
+    // データ行は存在しない
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("フィールドがない馬でも正常に表示される", () => {
+    const horsesWithoutFields: Horse[] = [
+      {
+        name: "シンプル馬",
+        predictionMark: "MUZIRUSHI",
+        fields: []
+      }
+    ];
+
+    render(
+      <MemoTable
+        horses={horsesWithoutFields}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    expect(screen.getByDisplayValue("シンプル馬")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    // MUZIRUSHI のマークを確認（全角スペースは特別な処理が必要）
+    const muzirushiButton = screen.getByRole("button", { name: "予想印を変更" });
+    expect(muzirushiButton).toBeInTheDocument();
+  });
+
+  it("Enterキーでフォーカス移動が機能する", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    const firstNameInput = screen.getByDisplayValue("テストホース1");
+    
+    // Enterキーを押下
+    fireEvent.keyDown(firstNameInput, { key: "Enter" });
+
+    // onBlurNameが呼ばれることを確認
+    expect(mockOnBlurName).toHaveBeenCalledWith(0, "テストホース1");
+  });
+
+  it("Shift+Enterで前の行にフォーカス移動する", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    const secondNameInput = screen.getByDisplayValue("テストホース2");
+    
+    // Shift+Enterキーを押下
+    fireEvent.keyDown(secondNameInput, { key: "Enter", shiftKey: true });
+
+    // onBlurNameが呼ばれることを確認
+    expect(mockOnBlurName).toHaveBeenCalledWith(1, "テストホース2");
+  });
+
+  it("テーブルの幅が内容に応じて調整される", () => {
+    render(
+      <MemoTable
+        horses={mockHorses}
+        onChangeMark={mockOnChangeMark}
+        onBlurName={mockOnBlurName}
+        onBlurField={mockOnBlurField}
+      />
+    );
+
+    // テーブルの外側コンテナのスタイルを確認
+    const tableContainer = screen.getByText("印").closest('div[style*="overflow-x"]');
+    expect(tableContainer).toHaveStyle({ width: "fit-content" });
+  });
+});

--- a/apps/web/src/app/memo/[id]/page.tsx
+++ b/apps/web/src/app/memo/[id]/page.tsx
@@ -1,0 +1,6 @@
+"use client";
+import { MemoPage } from "@/components/memo/MemoPage";
+
+export default function Page() {
+  return <MemoPage />;
+}

--- a/apps/web/src/components/home/_modals/CreateMemoModal.tsx
+++ b/apps/web/src/components/home/_modals/CreateMemoModal.tsx
@@ -10,6 +10,7 @@ type PredictionMark =
   | "RENSHITA"  // 連下
   | "HOSHI"     // ☆
   | "CHUUI"     // 注意
+  | "KESHI"     //消し
   | "MUZIRUSHI"; // 無印
 
 const DEFAULT_MARK: PredictionMark = "MUZIRUSHI";

--- a/apps/web/src/components/memo/MemoPage.tsx
+++ b/apps/web/src/components/memo/MemoPage.tsx
@@ -1,0 +1,82 @@
+"use client";
+import React, { useState } from "react";
+import { useMutation, useQuery } from "@apollo/client";
+import { useParams } from "next/navigation";
+import { Memo, FieldType, PredictionMark } from "./types";
+import { MemoTable } from "./table/MemoTable";
+import { GET_MEMO, SET_HORSE_PROP, SET_FIELD_VALUE } from "./queries";
+
+export function MemoPage(): React.JSX.Element {
+  const params = useParams<{ id: string }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  
+  const { data, loading, error, refetch } = useQuery(GET_MEMO, {
+    variables: { id },
+    fetchPolicy: "cache-and-network",
+  });
+  
+  const [setHorseProp] = useMutation(SET_HORSE_PROP);
+  const [setFieldValue] = useMutation(SET_FIELD_VALUE);
+  const [saving, setSaving] = useState(false);
+  
+  const memo: Memo = data?.item;
+  const horses = memo?.horses ?? [];
+
+  if (loading) return <div style={{ padding: 16 }}>読み込み中…</div>;
+  if (error) return <div style={{ padding: 16, color: "#c00" }}>読み込みエラー: {error.message}</div>;
+  if (!memo) return <div style={{ padding: 16 }}>メモが見つかりません</div>;
+
+  const onChangeMark = async (row: number, value: PredictionMark) => {
+    setSaving(true);
+    try {
+      await setHorseProp({ variables: { memoId: memo.id, index: row, predictionMark: value } });
+      await refetch();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onBlurName = async (row: number, value: string) => {
+    if (value === horses[row]?.name) return;
+    setSaving(true);
+    try {
+      await setHorseProp({ variables: { memoId: memo.id, index: row, name: value } });
+      await refetch();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onBlurField = async (row: number, label: string, type: FieldType, value: string) => {
+    let v: unknown = value;
+    if (type === "NUMBER") {
+      if (value === "") v = null;
+      else if (!/^-?\d+(\.\d+)?$/.test(value)) return;
+      else v = Number(value);
+    }
+    setSaving(true);
+    try {
+      await setFieldValue({ variables: { memoId: memo.id, index: row, label, type, value: v } });
+      await refetch();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h1 style={{ marginBottom: 12 }}>{memo.name}</h1>
+
+      <MemoTable
+        horses={horses}
+        onChangeMark={onChangeMark}
+        onBlurName={onBlurName}
+        onBlurField={onBlurField}
+      />
+
+      <div style={{ marginTop: 8, fontSize: 12, color: "#666" }}>
+        {saving ? "保存中…" : "　"}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/memo/queries.ts
+++ b/apps/web/src/components/memo/queries.ts
@@ -1,0 +1,32 @@
+import { gql } from "@apollo/client";
+
+export const GET_MEMO = gql`
+  query($id: ID!) {
+    item(id: $id) {
+      id name path type
+      horses {
+        name
+        predictionMark
+        fields { label type value }
+      }
+    }
+  }
+`;
+
+export const SET_HORSE_PROP = gql`
+  mutation($memoId: ID!, $index: Int!, $name: String, $predictionMark: PredictionMark) {
+    setHorseProp(memoId: $memoId, index: $index, name: $name, predictionMark: $predictionMark) {
+      id
+      horses { name predictionMark fields { label type value } }
+    }
+  }
+`;
+
+export const SET_FIELD_VALUE = gql`
+  mutation($memoId: ID!, $index: Int!, $label: String!, $type: FieldType!, $value: JSON) {
+    setHorseFieldValue(memoId: $memoId, index: $index, label: $label, type: $type, value: $value) {
+      id
+      horses { name predictionMark fields { label type value } }
+    }
+  }
+`;

--- a/apps/web/src/components/memo/table/EditableCell.tsx
+++ b/apps/web/src/components/memo/table/EditableCell.tsx
@@ -1,0 +1,61 @@
+"use client";
+import React from "react";
+import { FieldType } from "../types";
+import { editableCell, input } from "./TableStyles";
+
+type Props = {
+  index: number;
+  isLast?: boolean;
+  value: string | number | null;
+  type: FieldType;
+  placeholder?: string;
+  onBlur: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  inputRef?: (el: HTMLInputElement | null) => void;
+};
+
+export function EditableCell({
+  index,
+  isLast = false,
+  value,
+  type,
+  placeholder,
+  onBlur,
+  onKeyDown,
+  inputRef,
+}: Props): React.JSX.Element {
+  const displayValue = value === null ? "" : String(value);
+  const lastValueRef = React.useRef<string>(displayValue);
+  
+  // 値の重複を防ぐためのblurハンドラー
+  const handleBlur = React.useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    const currentValue = e.target.value;
+    
+    // 値が変更されていない場合は処理をスキップ
+    if (currentValue === lastValueRef.current) {
+      return;
+    }
+    
+    lastValueRef.current = currentValue;
+    onBlur(currentValue);
+  }, [onBlur]);
+  
+  // displayValueが変更されたときにlastValueRefを更新
+  React.useEffect(() => {
+    lastValueRef.current = displayValue;
+  }, [displayValue]);
+  
+  return (
+    <div className="editable-cell" style={editableCell(index, isLast)}>
+      <input
+        ref={inputRef}
+        inputMode={type === "NUMBER" ? "decimal" : undefined}
+        defaultValue={displayValue}
+        onBlur={handleBlur}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        style={input}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/memo/table/MarkSwitcher.tsx
+++ b/apps/web/src/components/memo/table/MarkSwitcher.tsx
@@ -1,0 +1,132 @@
+"use client";
+import React, { useRef, useState } from "react";
+import { PredictionMark, MARK_ORDER, MARK_LABEL } from "../types";
+
+function nextMark(cur: PredictionMark, reverse = false): PredictionMark {
+  const i = MARK_ORDER.indexOf(cur);
+  if (i < 0) return "MUZIRUSHI";
+  const n = MARK_ORDER.length;
+  return MARK_ORDER[(i + (reverse ? n - 1 : 1)) % n];
+}
+
+type Props = {
+  value: PredictionMark;
+  onChange: (v: PredictionMark) => void;
+};
+
+export function MarkSwitcher({ value, onChange }: Props): React.JSX.Element {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [longPressing, setLongPressing] = useState(false);
+  const btnRef = useRef<HTMLButtonElement|null>(null);
+  const timerRef = useRef<number|undefined>(undefined);
+
+  // 長押しでメニューを変更できるように
+  const onPointerDown = () => {
+    setLongPressing(false);
+    timerRef.current = window.setTimeout(() => {
+      setLongPressing(true);
+      setMenuOpen(true);
+    }, 250);
+  };
+  
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  };
+  
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (!longPressing) {
+      const reverse = e.shiftKey || e.altKey;
+      onChange(nextMark(value, reverse));
+    }
+    clearTimer();
+  };
+
+  // キー操作: Space/Enterで順送り、Shiftで逆
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      onChange(nextMark(value, e.shiftKey));
+    }
+    if (e.key === "Escape") setMenuOpen(false);
+  };
+
+  return (
+    <div style={{ position: "relative", display: "inline-block" }}>
+      <button
+        ref={btnRef}
+        type="button"
+        aria-label="予想印を変更"
+        title="クリック:順送り / Shift+クリック:逆送り / 長押し:一覧"
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+        onPointerLeave={clearTimer}
+        onKeyDown={onKeyDown}
+        style={{
+          minWidth: 36,
+          height: 32,
+          border: "1px solid #ddd",
+          borderRadius: 6,
+          background: "#fff",
+          cursor: "pointer",
+          font: "inherit",
+        }}
+      >
+        {MARK_LABEL[value]}
+      </button>
+
+      {menuOpen && (
+        <>
+          <div
+            onClick={() => setMenuOpen(false)}
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 10,
+            }}
+          />
+          <div
+            role="menu"
+            style={{
+              position: "absolute",
+              zIndex: 11,
+              top: "110%",
+              left: 0,
+              background: "#fff",
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              boxShadow: "0 10px 30px rgba(0,0,0,.12)",
+              padding: 6,
+              display: "grid",
+              gridTemplateColumns: "repeat(4, 36px)",
+              gap: 6,
+            }}
+          >
+            {MARK_ORDER.map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => { onChange(m); setMenuOpen(false); }}
+                title={m}
+                style={{
+                  width: 36,
+                  height: 32,
+                  border: "1px solid #ddd",
+                  borderRadius: 6,
+                  background: value === m ? "#111827" : "#fff",
+                  color: value === m ? "#fff" : "#111827",
+                  cursor: "pointer",
+                  font: "inherit",
+                }}
+              >
+                {MARK_LABEL[m]}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/memo/table/MemoTable.tsx
+++ b/apps/web/src/components/memo/table/MemoTable.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from "react";
+import { Horse, FieldType, PredictionMark } from "../types";
+import { useTableColumns } from "./useTableColumns";
+import { TableHeader } from "./TableHeader";
+import { MemoTableBody } from "./MemoTableBody";
+import { sheet, focusStyle } from "./TableStyles";
+
+type Props = {
+  horses: Horse[];
+  onChangeMark: (row: number, value: PredictionMark) => Promise<void>;
+  onBlurName: (row: number, value: string) => Promise<void>;
+  onBlurField: (row: number, label: string, type: FieldType, value: string) => Promise<void>;
+};
+
+export function MemoTable({ horses, onChangeMark, onBlurName, onBlurField }: Props): React.JSX.Element {
+  const { colLabels, gridTemplate, startResize } = useTableColumns(horses);
+
+  return (
+    <>
+      <style>{focusStyle}</style>
+      <div style={{ overflowX: "auto", width: "fit-content" }}>
+        <div style={sheet}>
+          <TableHeader
+            gridTemplate={gridTemplate}
+            colLabels={colLabels}
+            onStartResize={startResize}
+          />
+          <MemoTableBody
+            horses={horses}
+            gridTemplate={gridTemplate}
+            colLabels={colLabels}
+            onChangeMark={onChangeMark}
+            onBlurName={onBlurName}
+            onBlurField={onBlurField}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/memo/table/MemoTableBody.tsx
+++ b/apps/web/src/components/memo/table/MemoTableBody.tsx
@@ -1,0 +1,69 @@
+"use client";
+import React, { useRef, useCallback } from "react";
+import { Horse, FieldType, PredictionMark } from "../types";
+import { TableRow } from "./TableRow";
+
+type Props = {
+  horses: Horse[];
+  gridTemplate: string;
+  colLabels: string[];
+  onChangeMark: (row: number, value: PredictionMark) => Promise<void>;
+  onBlurName: (row: number, value: string) => Promise<void>;
+  onBlurField: (row: number, label: string, type: FieldType, value: string) => Promise<void>;
+};
+
+export function MemoTableBody({
+  horses,
+  gridTemplate,
+  colLabels,
+  onChangeMark,
+  onBlurName,
+  onBlurField,
+}: Props): React.JSX.Element {
+  const nameRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const focusTimeoutRef = useRef<number | null>(null);
+
+  const focusRow = useCallback((row: number) => {
+    if (row < 0 || row >= horses.length) return;
+    
+    if (focusTimeoutRef.current) {
+      clearTimeout(focusTimeoutRef.current);
+    }
+    
+    focusTimeoutRef.current = window.setTimeout(() => {
+      nameRefs.current[row]?.focus();
+      nameRefs.current[row]?.select?.();
+      focusTimeoutRef.current = null;
+    }, 10);
+  }, [horses.length]);
+
+  React.useEffect(() => {
+    return () => {
+      if (focusTimeoutRef.current) {
+        clearTimeout(focusTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <>
+      {horses.map((horse, r) => (
+        <TableRow
+          key={r}
+          horse={horse}
+          rowIndex={r}
+          gridTemplate={gridTemplate}
+          colLabels={colLabels}
+          onChangeMark={(value) => onChangeMark(r, value)}
+          onBlurName={(value) => onBlurName(r, value)}
+          onBlurField={(label, type, value) => onBlurField(r, label, type, value)}
+          onFocusRow={(direction) => {
+            const targetRow = direction === "prev" ? r - 1 : r + 1;
+            focusRow(targetRow);
+          }}
+          nameInputRef={(el) => (nameRefs.current[r] = el)}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/web/src/components/memo/table/ResizeHandle.tsx
+++ b/apps/web/src/components/memo/table/ResizeHandle.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React from "react";
+
+type Props = {
+  onMouseDown: (e: React.MouseEvent) => void;
+};
+
+export function ResizeHandle({ onMouseDown }: Props): React.JSX.Element {
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      title="ドラッグで列の幅を調整"
+      style={{
+        position: "absolute",
+        top: 0,
+        right: -3,
+        width: 6,
+        height: "100%",
+        cursor: "col-resize",
+        background: "rgba(0,0,0,0.04)"
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/memo/table/TableHeader.tsx
+++ b/apps/web/src/components/memo/table/TableHeader.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React from "react";
+import { ResizeHandle } from "./ResizeHandle";
+import { cell, row } from "./TableStyles";
+
+type Props = {
+  gridTemplate: string;
+  colLabels: string[];
+  onStartResize: (e: React.MouseEvent, which: "name" | number) => void;
+};
+
+export function TableHeader({ gridTemplate, colLabels, onStartResize }: Props): React.JSX.Element {
+  return (
+    <div style={{ ...row, gridTemplateColumns: gridTemplate, background: "#f9fafb" }}>
+      <div style={{ ...cell(0), fontWeight: 600 }}>印</div>
+      
+      <div style={{ ...cell(1), fontWeight: 600, justifyContent: "center" }}>番</div>
+
+      <div style={{ ...cell(2, colLabels.length === 0), position: "relative", fontWeight: 600 }}>
+        名前
+        <ResizeHandle onMouseDown={(e) => onStartResize(e, "name")} />
+      </div>
+
+      {colLabels.map((l, i) => {
+        const isLastColumn = i === colLabels.length - 1;
+        return (
+          <div key={l} style={{ ...cell(i + 3, isLastColumn), position: "relative", fontWeight: 600 }}>
+            {l}
+            <ResizeHandle onMouseDown={(e) => onStartResize(e, i)} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/memo/table/TableRow.tsx
+++ b/apps/web/src/components/memo/table/TableRow.tsx
@@ -1,0 +1,103 @@
+"use client";
+import React from "react";
+import { Horse, FieldType, PredictionMark } from "../types";
+import { MarkSwitcher } from "./MarkSwitcher";
+import { EditableCell } from "./EditableCell";
+import { cell, row } from "./TableStyles";
+
+type Props = {
+  horse: Horse;
+  rowIndex: number;
+  gridTemplate: string;
+  colLabels: string[];
+  onChangeMark: (value: PredictionMark) => void;
+  onBlurName: (value: string) => void;
+  onBlurField: (label: string, type: FieldType, value: string) => void;
+  onFocusRow: (direction: "prev" | "next") => void;
+  nameInputRef?: (el: HTMLInputElement | null) => void;
+};
+
+export function TableRow({
+  horse,
+  rowIndex,
+  gridTemplate,
+  colLabels,
+  onChangeMark,
+  onBlurName,
+  onBlurField,
+  onFocusRow,
+  nameInputRef,
+}: Props): React.JSX.Element {
+  const findField = (label: string) =>
+    (horse.fields ?? []).find((f) => f.label === label);
+
+  const isEliminated = horse.predictionMark === "KESHI";
+  const rowBgColor = isEliminated ? "rgba(0, 0, 0, 0.4)" : "transparent";
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      
+      const currentValue = e.currentTarget.value;
+      onBlurName(currentValue);
+      
+      setTimeout(() => {
+        if (e.shiftKey) onFocusRow("prev");
+        else onFocusRow("next");
+      }, 5);
+    }
+  };
+
+  return (
+    <div key={rowIndex} style={{ 
+      ...row, 
+      gridTemplateColumns: gridTemplate,
+      backgroundColor: rowBgColor,
+      transition: "background-color 0.2s ease"
+    }}>
+      {/* 印 */}
+      <div style={cell(0)}>
+        <MarkSwitcher
+          value={(horse.predictionMark as PredictionMark) || "MUZIRUSHI"}
+          onChange={onChangeMark}
+        />
+      </div>
+
+      {/* 番号 */}
+      <div style={{ ...cell(1), justifyContent: "center", fontSize: "14px", color: "#666" }}>
+        {rowIndex + 1}
+      </div>
+
+      {/* 馬名（列幅に追従） */}
+      <EditableCell
+        index={2}
+        isLast={colLabels.length === 0}
+        value={horse.name || ""}
+        type="COMMENT"
+        onBlur={onBlurName}
+        onKeyDown={handleKeyDown}
+        inputRef={nameInputRef}
+      />
+
+      {/* 可変列 */}
+      {colLabels.map((label, i) => {
+        const f = findField(label);
+        const type = (f?.type || "COMMENT") as FieldType;
+        const val = f?.value ?? "";
+        const isLastColumn = i === colLabels.length - 1;
+
+        return (
+          <EditableCell
+            key={label}
+            index={i + 3}
+            isLast={isLastColumn}
+            value={val}
+            type={type}
+            placeholder={type === "SELECT" ? "選択値" : type === "NUMBER" ? "数値" : "コメント"}
+            onBlur={(value) => onBlurField(label, type, value)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/memo/table/TableStyles.ts
+++ b/apps/web/src/components/memo/table/TableStyles.ts
@@ -1,0 +1,50 @@
+import React from "react";
+
+export const sheet: React.CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  overflow: "hidden",
+  background: "#fff",
+};
+
+export const row: React.CSSProperties = {
+  display: "grid",
+  // gridTemplateColumns は行ごとに上で可変設定
+};
+
+export const cell = (index: number, isLast = false): React.CSSProperties => ({
+  padding: "4px 8px",
+  borderTop: "1px solid #e5e7eb",
+  borderLeft: index === 0 ? "none" : "1px solid #e5e7eb",
+  borderRight: isLast ? "1px solid #e5e7eb" : "none",
+  display: "flex",
+  alignItems: "center",
+  minHeight: "32px",
+});
+
+export const input: React.CSSProperties = {
+  border: "none",
+  outline: "none",
+  background: "transparent",
+  width: "100%",
+  font: "inherit",
+  minWidth: 0,
+  padding: "2px 0",
+};
+
+export const editableCell = (index: number, isLast = false): React.CSSProperties => ({
+  ...cell(index, isLast),
+  cursor: "text",
+  transition: "background-color 0.1s ease",
+});
+
+// フォーカス時のスタイル用CSS
+export const focusStyle = `
+  .editable-cell:hover {
+    background-color: #f8fafc;
+  }
+  .editable-cell:focus-within {
+    background-color: #f1f5f9;
+    box-shadow: inset 0 0 0 1px #3b82f6;
+  }
+`;

--- a/apps/web/src/components/memo/table/useTableColumns.ts
+++ b/apps/web/src/components/memo/table/useTableColumns.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from "react";
+import { Horse } from "../types";
+
+export function useTableColumns(horses: Horse[]) {
+  const MIN_W = 96;   // 列の最小幅(px)
+  const MAX_W = 560;  // 列の最大幅(px)
+  
+  const [nameColW, setNameColW] = useState<number>(160);       // 馬名列
+  const [fieldColW, setFieldColW] = useState<number[]>([]);
+  
+  // 列の合成（fields[].label のユニーク順）
+  const colLabels: string[] = useMemo(() => {
+    const set = new Set<string>();
+    horses.forEach((h) => (h.fields ?? []).forEach((f) => set.add(f.label)));
+    return Array.from(set);
+  }, [horses]);
+  
+  useEffect(() => {
+    setFieldColW((prev) => {
+      const next = [...prev];
+      for (let i = 0; i < colLabels.length; i++) {
+        if (next[i] == null) next[i] = 140;
+      }
+      return next.slice(0, colLabels.length);
+    });
+  }, [colLabels]);
+
+  function startResize(
+    e: React.MouseEvent,
+    which: "name" | number
+  ) {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = which === "name" ? nameColW : fieldColW[which] ?? 140;
+
+    const onMove = (ev: MouseEvent) => {
+      const w = Math.max(MIN_W, Math.min(MAX_W, startW + (ev.clientX - startX)));
+      if (which === "name") setNameColW(w);
+      else setFieldColW((arr) => {
+        const copy = [...arr];
+        copy[which] = w;
+        return copy;
+      });
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  // グリッドテンプレートの生成
+  const gridTemplate = [
+    "56px",                            // 印
+    "42px",                            // 番号
+    `${nameColW}px`,                   // 馬名
+    ...fieldColW.map((w) => `${w}px`)  // 可変列
+  ].join(" ");
+
+  return {
+    colLabels,
+    gridTemplate,
+    startResize,
+  };
+}

--- a/apps/web/src/components/memo/types.ts
+++ b/apps/web/src/components/memo/types.ts
@@ -1,0 +1,41 @@
+export type FieldType = "NUMBER" | "SELECT" | "COMMENT";
+
+export type PredictionMark =
+  | "HONMEI" | "TAIKOU" | "TANNANA" | "RENSHITA"
+  | "HOSHI"  | "CHUUI"  | "KESHI"    | "MUZIRUSHI";
+
+export type Field = {
+  label: string;
+  type: FieldType;
+  value: string | number | null;
+};
+
+export type Horse = {
+  name: string;
+  predictionMark: PredictionMark;
+  fields: Field[];
+};
+
+export type Memo = {
+  id: string;
+  name: string;
+  path: string;
+  type: string;
+  horses: Horse[];
+};
+
+export const MARK_ORDER: PredictionMark[] = [
+  "MUZIRUSHI", "HONMEI", "TAIKOU", "TANNANA",
+  "RENSHITA", "HOSHI", "CHUUI", "KESHI",
+];
+
+export const MARK_LABEL: Record<PredictionMark, string> = {
+  HONMEI: "◎",
+  TAIKOU: "◯",
+  TANNANA: "▲",
+  RENSHITA: "△",
+  HOSHI: "☆",
+  CHUUI: "注",
+  KESHI: "消",
+  MUZIRUSHI: "　",
+};

--- a/packages/server/_test_/items.horse-operations.test.ts
+++ b/packages/server/_test_/items.horse-operations.test.ts
@@ -1,0 +1,526 @@
+import { beforeAll, afterAll, test, expect, vi } from "vitest";
+vi.mock("../services/firebaseAdmin.js", () => ({
+  getFirebaseAuth: () => ({
+    verifyIdToken: async (token: string) =>
+      token?.includes("userB")
+        ? { uid: "user-b", email: "b@example.com" }
+        : { uid: "user-a", email: "a@example.com" },
+  }),
+}));
+
+import http from "http";
+import getPort from "get-port";
+import { setupMongo, teardownMongo } from "./helpers/setup.mongo.js";
+import { buildApp } from "../src/server.js";
+
+let server: http.Server;
+let url: string;
+const authA = { authorization: "Bearer userA" };
+const authB = { authorization: "Bearer userB" };
+
+async function gql(query: string, variables?: any, headers?: Record<string,string>) {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(headers || {}) },
+    body: JSON.stringify({ query, variables }),
+  });
+  return r.json();
+}
+
+beforeAll(async () => {
+  await setupMongo();
+  const { app } = await buildApp({ webOrigin: "http://localhost:3000" });
+  const port = await getPort();
+  server = http.createServer(app);
+  await new Promise<void>((res) => server.listen(port, res));
+  url = `http://localhost:${port}/graphql`;
+}, 20000);
+
+afterAll(async () => {
+  await new Promise<void>((res) => server.close(() => res()));
+  await teardownMongo();
+}, 20000);
+
+// Helper function to create a test memo with horses
+async function createTestMemo(auth: Record<string, string>) {
+  const timestamp = Date.now();
+  const folderResult = await gql(
+    `mutation($input:CreateFolderInput!){ createFolder(input:$input){ id } }`,
+    { input: { name: `test-folder-${timestamp}`, parentId: null } },
+    auth
+  );
+  
+  if (!folderResult.data?.createFolder?.id) {
+    throw new Error(`Failed to create folder: ${JSON.stringify(folderResult)}`);
+  }
+  
+  const folderId = folderResult.data.createFolder.id;
+
+  const memoResult = await gql(
+    `mutation($input:CreateMemoInput!){ createMemo(input:$input){ id horses { name predictionMark fields { label type value } } } }`,
+    { 
+      input: { 
+        name: `test-memo-${timestamp}`, 
+        parentId: folderId, 
+        horses: [
+          { name: "テストホース1", predictionMark: "HONMEI", fields: [] },
+          { name: "テストホース2", predictionMark: "TAIKOU", fields: [{ label: "体重", type: "NUMBER", value: 480 }] }
+        ]
+      } 
+    },
+    auth
+  );
+  
+  if (!memoResult.data?.createMemo?.id) {
+    throw new Error(`Failed to create memo: ${JSON.stringify(memoResult)}`);
+  }
+  
+  return memoResult.data.createMemo;
+}
+
+/** setHorseProp Tests */
+
+test("setHorseProp: successfully update horse name", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { 
+        id horses { name predictionMark } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, name: "新しい馬名" },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data.setHorseProp.horses[0].name).toBe("新しい馬名");
+  expect(result.data.setHorseProp.horses[0].predictionMark).toBe("HONMEI");
+}, 20000);
+
+test("setHorseProp: successfully update prediction mark", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $predictionMark:PredictionMark) { 
+      setHorseProp(memoId:$memoId, index:$index, predictionMark:$predictionMark) { 
+        horses { name predictionMark } 
+      } 
+    }`,
+    { memoId: memo.id, index: 1, predictionMark: "CHUUI" },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data.setHorseProp.horses[1].name).toBe("テストホース2");
+  expect(result.data.setHorseProp.horses[1].predictionMark).toBe("CHUUI");
+}, 20000);
+
+test("setHorseProp: update both name and prediction mark", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String, $predictionMark:PredictionMark) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name, predictionMark:$predictionMark) { 
+        horses { name predictionMark } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, name: "両方更新", predictionMark: "KESHI" },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data.setHorseProp.horses[0].name).toBe("両方更新");
+  expect(result.data.setHorseProp.horses[0].predictionMark).toBe("KESHI");
+}, 20000);
+
+test("setHorseProp: trim whitespace from horse name", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { 
+        horses { name } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, name: "  スペース付き  " },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data.setHorseProp.horses[0].name).toBe("スペース付き");
+}, 20000);
+
+test("setHorseProp: UNAUTHENTICATED when no auth", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: memo.id, index: 0, name: "test" }
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/UNAUTHENTICATED/i);
+}, 20000);
+
+test("setHorseProp: MEMO_NOT_FOUND for non-existent memo", async () => {
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: "507f1f77bcf86cd799439011", index: 0, name: "test" },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/MEMO_NOT_FOUND/i);
+}, 20000);
+
+test("setHorseProp: MEMO_NOT_FOUND when accessing other user's memo", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: memo.id, index: 0, name: "test" },
+    authB
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/MEMO_NOT_FOUND/i);
+}, 20000);
+
+test("setHorseProp: INDEX_OUT_OF_RANGE for negative index", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: memo.id, index: -1, name: "test" },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INDEX_OUT_OF_RANGE/i);
+}, 20000);
+
+test("setHorseProp: INDEX_OUT_OF_RANGE for index beyond array", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: memo.id, index: 10, name: "test" },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INDEX_OUT_OF_RANGE/i);
+}, 20000);
+
+test("setHorseProp: HORSE_NAME_TOO_LONG for name exceeding 80 chars", async () => {
+  const memo = await createTestMemo(authA);
+  const longName = "a".repeat(81);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { id } 
+    }`,
+    { memoId: memo.id, index: 0, name: longName },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/HORSE_NAME_TOO_LONG/i);
+}, 20000);
+
+test("setHorseProp: INVALID_PREDICTION_MARK for invalid mark", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $predictionMark:PredictionMark) { 
+      setHorseProp(memoId:$memoId, index:$index, predictionMark:$predictionMark) { id } 
+    }`,
+    { memoId: memo.id, index: 0, predictionMark: "INVALID_MARK" },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INVALID_PREDICTION_MARK|Variable/i);
+}, 20000);
+
+test("setHorseProp: accept maximum length name (80 chars)", async () => {
+  const memo = await createTestMemo(authA);
+  const maxName = "a".repeat(80);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $name:String) { 
+      setHorseProp(memoId:$memoId, index:$index, name:$name) { 
+        horses { name } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, name: maxName },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data.setHorseProp.horses[0].name).toBe(maxName);
+}, 20000);
+
+/** setHorseFieldValue Tests */
+
+test("setHorseFieldValue: successfully set new field", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "新しいフィールド", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  const fields = result.data.setHorseFieldValue.horses[0].fields;
+  expect(fields.some((f: any) => f.label === "新しいフィールド" && f.type === "NUMBER" && f.value === 123)).toBe(true);
+}, 20000);
+
+test("setHorseFieldValue: successfully update existing field", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 1, label: "体重", type: "NUMBER", value: 500 },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  const field = result.data.setHorseFieldValue.horses[1].fields.find((f: any) => f.label === "体重");
+  expect(field.value).toBe(500);
+  expect(field.type).toBe("NUMBER");
+}, 20000);
+
+test("setHorseFieldValue: set different field types", async () => {
+  const memo = await createTestMemo(authA);
+  
+  // NUMBER field
+  const r1 = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "数値", type: "NUMBER", value: 42 },
+    authA
+  );
+  
+  // SELECT field
+  const r2 = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "選択", type: "SELECT", value: "選択肢A" },
+    authA
+  );
+  
+  // COMMENT field
+  const r3 = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "コメント", type: "COMMENT", value: "テストコメント" },
+    authA
+  );
+
+  expect(r1.errors).toBeUndefined();
+  expect(r2.errors).toBeUndefined();
+  expect(r3.errors).toBeUndefined();
+  
+  const fields = r3.data.setHorseFieldValue.horses[0].fields;
+  expect(fields.find((f: any) => f.label === "数値")?.value).toBe(42);
+  expect(fields.find((f: any) => f.label === "選択")?.value).toBe("選択肢A");
+  expect(fields.find((f: any) => f.label === "コメント")?.value).toBe("テストコメント");
+}, 20000);
+
+test("setHorseFieldValue: trim whitespace from field label", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "  スペース付きラベル  ", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  const field = result.data.setHorseFieldValue.horses[0].fields.find((f: any) => f.label === "スペース付きラベル");
+  expect(field).toBeDefined();
+}, 20000);
+
+test("setHorseFieldValue: UNAUTHENTICATED when no auth", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 0, label: "test", type: "NUMBER", value: 123 }
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/UNAUTHENTICATED/i);
+}, 20000);
+
+test("setHorseFieldValue: MEMO_NOT_FOUND for non-existent memo", async () => {
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: "507f1f77bcf86cd799439011", index: 0, label: "test", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/MEMO_NOT_FOUND/i);
+}, 20000);
+
+test("setHorseFieldValue: MEMO_NOT_FOUND when accessing other user's memo", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 0, label: "test", type: "NUMBER", value: 123 },
+    authB
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/MEMO_NOT_FOUND/i);
+}, 20000);
+
+test("setHorseFieldValue: INDEX_OUT_OF_RANGE for negative index", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: -1, label: "test", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INDEX_OUT_OF_RANGE/i);
+}, 20000);
+
+test("setHorseFieldValue: INDEX_OUT_OF_RANGE for index beyond array", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 10, label: "test", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INDEX_OUT_OF_RANGE/i);
+}, 20000);
+
+test("setHorseFieldValue: FIELD_LABEL_REQUIRED for empty label", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 0, label: "", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/FIELD_LABEL_REQUIRED/i);
+}, 20000);
+
+test("setHorseFieldValue: FIELD_LABEL_REQUIRED for whitespace-only label", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 0, label: "   ", type: "NUMBER", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/FIELD_LABEL_REQUIRED/i);
+}, 20000);
+
+test("setHorseFieldValue: FIELD_TYPE_MISMATCH when changing existing field type", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 1, label: "体重", type: "SELECT", value: "選択肢" },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/FIELD_TYPE_MISMATCH/i);
+}, 20000);
+
+test("setHorseFieldValue: INVALID_FIELD_TYPE for invalid type", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { id } 
+    }`,
+    { memoId: memo.id, index: 0, label: "test", type: "INVALID_TYPE", value: 123 },
+    authA
+  );
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors[0].message).toMatch(/INVALID_FIELD_TYPE|Variable/i);
+}, 20000);
+
+test("setHorseFieldValue: set null value", async () => {
+  const memo = await createTestMemo(authA);
+  
+  const result = await gql(
+    `mutation($memoId:ID!, $index:Int!, $label:String!, $type:FieldType!, $value:JSON) { 
+      setHorseFieldValue(memoId:$memoId, index:$index, label:$label, type:$type, value:$value) { 
+        horses { fields { label type value } } 
+      } 
+    }`,
+    { memoId: memo.id, index: 0, label: "null値", type: "NUMBER", value: null },
+    authA
+  );
+
+  expect(result.errors).toBeUndefined();
+  const field = result.data.setHorseFieldValue.horses[0].fields.find((f: any) => f.label === "null値");
+  expect(field.value).toBeNull();
+}, 20000);

--- a/packages/server/graphql/items/item.resolver.ts
+++ b/packages/server/graphql/items/item.resolver.ts
@@ -181,9 +181,6 @@ export default {
         throw new GraphQLError("INDEX_OUT_OF_RANGE");
       }
 
-      const nextName = normalizeName(name);
-      const nextMark = normalizeMark(predictionMark);
-
       if (name !== undefined) {
         doc.horses[index].name = normalizeName(name);
       }

--- a/packages/server/graphql/items/schema.graphql
+++ b/packages/server/graphql/items/schema.graphql
@@ -7,6 +7,7 @@ enum PredictionMark {
   RENSHITA
   HOSHI
   CHUUI
+  KESHI
   MUZIRUSHI
 }
 
@@ -53,4 +54,21 @@ extend type Mutation {
 
 extend type Mutation {
   createFolder(input: CreateFolderInput!): Item!
+}
+
+extend type Mutation {
+  setHorseProp(
+    memoId: ID!
+    index: Int!
+    name: String
+    predictionMark: PredictionMark
+  ): Item!
+
+  setHorseFieldValue(
+    memoId: ID!
+    index: Int!
+    label: String!
+    type: FieldType!
+    value: JSON
+  ): Item!
 }

--- a/packages/server/models/Item.ts
+++ b/packages/server/models/Item.ts
@@ -22,7 +22,7 @@ const horseSchema = new Schema(
     // 予想印は必須（muzirushi など）にしてOK
     predictionMark: {
       type: String,
-      enum: ["HONMEI","TAIKOU","TANNANA","RENSHITA","HOSHI","CHUUI","MUZIRUSHI"],
+      enum: ["HONMEI","TAIKOU","TANNANA","RENSHITA","HOSHI","CHUUI","KESHI","MUZIRUSHI"],
       required: true,
       default: "MUZIRUSHI",
     },


### PR DESCRIPTION
## 変更点
- 最低限の機能のメモページを追加
- 印、番号、名前を必須フィールドとするテーブルを表示
- 入力ボックスの列の横幅をユーザーが設定可能
- 印をクリックのみで選択可能、長押しでメニューからも選択可能
- 入力ボックスはEnter/Enter + Shiftで上下移動できる
- 追加した機能のテスト作成